### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "pip install -r requirements.txt && python3 py_chatter_bot/app.py"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # py_chatter_bot
 
-basic little chat bot built using chatterbot and Python3 
+A basic little chat bot built using chatterbot and Python3 
+
+-----
+
+Check out this working example in your browser! 
+
+
+[![Run on Repl.it](https://repl.it/badge/github/keeganridgley107/py_chatter_bot)](https://repl.it/github/keeganridgley107/py_chatter_bot)
+


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@keeganridgley1/pychatterbot-1).